### PR TITLE
Replace a bunch of legacy facts with structured facts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,11 +119,11 @@ inherits backupninja::params
         fail("backupninja 'ensure' parameter must be set to either 'absent' or 'present'")
     }
 
-    case $::operatingsystem {
+    case $::facts['os']['name'] {
         'debian', 'ubuntu':          { include ::backupninja::common::debian }
         'centos', 'redhat', 'rocky': { include ::backupninja::common::redhat }
         default: {
-            fail("Module ${module_name} is not supported on ${::operatingsystem}")
+            fail("Module ${module_name} is not supported on ${::facts['os']['name']}")
         }
     }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,7 +49,7 @@ class backupninja::params {
     $when            = 'everyday at 01:00'
     $vservers        = 'no'
 
-    $libdirectory    = $::operatingsystem ? {
+    $libdirectory    = $::facts['os']['name'] ? {
         /(?i-mx:centos|fedora|redhat|rocky)/ => '/usr/libexec/backupninja',
         /(?i-mx:debian|ubuntu)/              => '/usr/lib/backupninja',
         default                              => '/usr/lib/backupninja'
@@ -59,32 +59,32 @@ class backupninja::params {
     # (Modify to adapt to unsupported OSes)
     #######################################
     # backupninja packages
-    $packagename = $::operatingsystem ? {
+    $packagename = $::facts['os']['name'] ? {
         default => 'backupninja',
     }
 
-    $configfile = $::operatingsystem ? {
+    $configfile = $::facts['os']['name'] ? {
         default => '/etc/backupninja.conf',
     }
-    $configfile_mode = $::operatingsystem ? {
+    $configfile_mode = $::facts['os']['name'] ? {
         default => '0644',
     }
-    $taskfile_mode = $::operatingsystem ? {
+    $taskfile_mode = $::facts['os']['name'] ? {
         default => '0600',
     }
-    $netbackup_mode = $::operatingsystem ? {
+    $netbackup_mode = $::facts['os']['name'] ? {
         default => '0755',
     }
-    $configfile_owner = $::operatingsystem ? {
+    $configfile_owner = $::facts['os']['name'] ? {
         default => 'root',
     }
-    $configfile_group = $::operatingsystem ? {
+    $configfile_group = $::facts['os']['name'] ? {
         default => 'root',
     }
-    $backupdir = $::operatingsystem ? {
+    $backupdir = $::facts['os']['name'] ? {
         default => '/var/backups',
     }
-    $backupdir_mode = $::operatingsystem ? {
+    $backupdir_mode = $::facts['os']['name'] ? {
         default => '0755',
     }
 


### PR DESCRIPTION
Puppet 8 disables legacy facts by default:
https://www.puppet.com/docs/puppet/8/upgrading-from-puppet7-to-puppet8.html#upgrading-from-puppet7-to-puppet8-legacy-facts-deprecation