### PR TITLE
[manifest] Ensure directory backup.d with chmod 0700

### DIFF
--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -19,6 +19,14 @@ class backupninja::common {
         name   => $backupninja::params::packagename,
     }
 
+    file { 'backup.d':
+        ensure  => 'directory',
+        path    => $backupninja::params::configdirectory,
+        owner   => $backupninja::params::configfile_owner,
+        group   => $backupninja::params::configfile_group,
+        mode    => '0700',
+        require => Package['backupninja'],
+    }
 
     file { 'backupninja.conf':
         ensure  => $backupninja::ensure,


### PR DESCRIPTION
Fixes this issue:

```
Fatal: Configuration files must not be world writable/readable! Dying on file /etc/backup.d
```